### PR TITLE
Add animated card preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
 import { useForm } from '@mantine/form';
 import { TextInput, NumberInput, Button, MantineProvider } from '@mantine/core';
 import '@mantine/core/styles.css';
+import { useState } from 'react';
+import CardPreview from './components/CardPreview';
 
 function App() {
+  const [showBack, setShowBack] = useState(false);
   const form = useForm({
     validateInputOnChange: true,
     validateInputOnBlur: true,
@@ -29,6 +32,13 @@ function App() {
     <MantineProvider>
       <main className="bg-zinc-5 h-screen w-screen pt-10">
         <section className="container mx-auto flex w-[600px] flex-col items-center">
+          <CardPreview
+            cardNumber={String(form.values.cardNumber)}
+            cardholder={form.values.cardholder}
+            expirationDate={String(form.values.expirationDate)}
+            cvv={String(form.values.cvv)}
+            showBack={showBack}
+          />
           <form
             className="flex w-[400px] flex-col items-center gap-4 rounded-lg border border-zinc-200 bg-white p-4"
             onSubmit={form.onSubmit(values => console.log(values))}
@@ -38,12 +48,14 @@ function App() {
               hideControls
               label="Card Number"
               placeholder="1234 5678 9012 3456"
+              onFocus={() => setShowBack(false)}
               {...form.getInputProps('cardNumber')}
             />
             <TextInput
               className="w-full"
               label="Cardholder"
               placeholder="John Doe"
+              onFocus={() => setShowBack(false)}
               {...form.getInputProps('cardholder')}
             />
             <div className="flex w-full gap-4">
@@ -53,6 +65,7 @@ function App() {
                 hideControls
                 label="Expiration Date"
                 placeholder="MM/YY"
+                onFocus={() => setShowBack(false)}
                 {...form.getInputProps('expirationDate')}
               />
               <NumberInput
@@ -61,6 +74,8 @@ function App() {
                 hideControls
                 label="CVV"
                 placeholder="123"
+                onFocus={() => setShowBack(true)}
+                onBlur={() => setShowBack(false)}
                 {...form.getInputProps('cvv')}
               />
             </div>

--- a/src/CardPreview.css
+++ b/src/CardPreview.css
@@ -1,0 +1,40 @@
+.card-container {
+  width: 320px;
+  height: 200px;
+  perspective: 1000px;
+}
+
+.card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+}
+
+.card.flipped {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.75rem;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem;
+  color: white;
+  box-sizing: border-box;
+}
+
+.card-front {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+}
+
+.card-back {
+  background: linear-gradient(135deg, #764ba2, #667eea);
+  transform: rotateY(180deg);
+}

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -1,0 +1,45 @@
+import '../CardPreview.css';
+
+interface Props {
+  cardNumber: string;
+  cardholder: string;
+  expirationDate: string;
+  cvv: string;
+  showBack: boolean;
+}
+
+const formatCardNumber = (value: string) => {
+  const digits = value.replace(/\s+/g, '').padEnd(16, '*').slice(0, 16);
+  return digits.replace(/(\d{4})(?=\d)/g, '$1 ').trim();
+};
+
+export function CardPreview({
+  cardNumber,
+  cardholder,
+  expirationDate,
+  cvv,
+  showBack,
+}: Props) {
+  return (
+    <div className="card-container mb-6">
+      <div className={showBack ? 'card flipped' : 'card'}>
+        <div className="card-face card-front">
+          <div className="text-lg tracking-widest mb-4">
+            {formatCardNumber(cardNumber)}
+          </div>
+          <div className="flex justify-between items-end text-sm">
+            <span className="uppercase">{cardholder || 'NAME SURNAME'}</span>
+            <span>{expirationDate || 'MM/YY'}</span>
+          </div>
+        </div>
+        <div className="card-face card-back flex flex-col justify-end items-end pr-4 pb-8">
+          <div className="bg-white text-black w-3/4 text-right px-2 py-1 rounded">
+            {cvv || '***'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CardPreview;


### PR DESCRIPTION
## Summary
- show a card preview that updates with form values
- flip the card to reveal CVV on focus
- style preview with basic CSS animations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846a6b479b4832aa67e825d834be37a